### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Edit or create SVG paths in browser: https://yqnn.github.io/svg-path-editor/
 Run `npm install` to retrieve all the depencies of the project.
 
 ##### Development server
-Run `ng serve` for a dev server. Navigate to `http://localhost:4200/`. The app will automatically reload if you change any of the source files.
+Run `ng serve` for a dev server. (Run `npm install -g @angular/cli`, if necessary.) Navigate to `http://localhost:4200/`. The app will automatically reload if you change any of the source files.
 
 ##### Build
 Run `ng build` to build the project. The build artifacts will be stored in the `dist/` directory. Use the `--prod` flag for a production build.


### PR DESCRIPTION
Hi!

Some people (like me 🙃 ) might not know about the Angular cli, which provides `ng`.  I found out about it through [the Angular setup](https://angular.io/guide/setup-local).  Would you consider adding a little note to "Run `npm install -g @angular/cli`, if necessary."?

Because the locally installed `ng` doesn't work; unless you know to do something like `node_modules/@angular/cli/bin/ng serve`.

Thank you for your consideration. 🙂 

Tammy